### PR TITLE
fix: contain svg to bounds of icon size

### DIFF
--- a/packages/library/components/icon/src/styles.css
+++ b/packages/library/components/icon/src/styles.css
@@ -6,6 +6,7 @@
   min-height: 10px; /* to give a minimum size to be observable */
 
   &,
+  & svg,
   & .icon {
     width: var(--icon-size, 100%);
     height: var(--icon-size, 100%);


### PR DESCRIPTION
- [x] resolving: https://github.com/centrica-engineering/muon/issues/121