### PR TITLE
change token name `choice` to `multiple`

### DIFF
--- a/packages/library/components/inputter/src/styles.css
+++ b/packages/library/components/inputter/src/styles.css
@@ -57,9 +57,9 @@
       position: relative;
       display: block;
       width: fit-content;
-      padding-inline-start: $INPUTTER_CHOICE_PADDING_INLINE;
-      margin-block-start: $INPUTTER_CHOICE_MARGIN_BLOCK;
-      margin-block-end: $INPUTTER_CHOICE_MARGIN_BLOCK;
+      padding-inline-start: $INPUTTER_MULTIPLE_PADDING_INLINE;
+      margin-block-start: $INPUTTER_MULTIPLE_MARGIN_BLOCK;
+      margin-block-end: $INPUTTER_MULTIPLE_MARGIN_BLOCK;
     }
   }
 

--- a/packages/library/components/inputter/src/token.json
+++ b/packages/library/components/inputter/src/token.json
@@ -56,7 +56,7 @@
         }
       }
     },
-    "choice": {
+    "multiple": {
       "icon": {
         "size": {
           "value": "{ theme.spacer.md.value }"
@@ -64,7 +64,7 @@
       },
       "padding": {
         "inline": {
-          "value": "calc({ inputter.choice.icon.size.value } + { inputter.field.padding.block.value })"
+          "value": "calc({ inputter.multiple.icon.size.value } + { inputter.field.padding.block.value })"
         }
       },
       "margin": {


### PR DESCRIPTION
The use of the collective noun `multiple` has been used in the inputter component to describe 'radio buttons and checkboxes'. Whereas, in the token and css, the word `choice` had been used.

- [x] Change the token and styles to use the word `multiple`
