### PR TITLE
fix: radio and checkbox vertical alignment

### DIFF
--- a/packages/library/components/inputter/src/styles.css
+++ b/packages/library/components/inputter/src/styles.css
@@ -46,7 +46,7 @@
     /* opacity: 0; /* NOTE: include this declaration if complex selectors slotted are included */
     position: absolute; /* NOTE: keep this declaration if complex selectors slotted are included */
     transform: scale(1.2308); /* NOTE: remove this if complex selectors slotted are included */
-    margin-block-start: 5px; /* NOTE: remove this if complex selectors slotted are included */
+    margin-block-start: 3px; /* NOTE: remove this if complex selectors slotted are included */
     margin-inline-start: 2px; /* NOTE: remove this if complex selectors slotted are included */
   }
 


### PR DESCRIPTION
- [x] Tweak the vertical alignment of the radio and checkbox

NOTE: This technique of displaying the checkbox and radio button is temporary. It'll change once we're able to apply styles to complex slotted selectors within the anonymous slot.