### PR TITLE
fix: stop icon from shrinking

### DIFF
--- a/packages/library/components/detail/src/styles.css
+++ b/packages/library/components/detail/src/styles.css
@@ -37,6 +37,8 @@
     & .icon,
     & .toggle {
       width: $DETAIL_TOGGLE_ICON_SIZE;
+      flex-shrink: 0;
+      align-self: baseline;
     }
 
     &:hover {

--- a/packages/library/components/inputter/src/inputter-detail-styles.css
+++ b/packages/library/components/inputter/src/inputter-detail-styles.css
@@ -14,6 +14,8 @@
 
   & .toggle {
     width: 1rem;
+    flex-shrink: 0;
+    align-self: baseline;
   }
 
   & .heading {

--- a/packages/library/components/inputter/src/styles.css
+++ b/packages/library/components/inputter/src/styles.css
@@ -171,6 +171,8 @@
 
     & .icon {
       width: $INPUTTER_VALIDATION_ICON_SIZE;
+      flex-shrink: 0;
+      align-self: baseline;
     }
   }
 


### PR DESCRIPTION
- [x] Stop the icon from shrinking in these components:
  - [x] details
  - [x] inputter-details
  - [x] inputter-validation

NOTE: Applying `align-self: baseline;` fixes the inconsistency with the position of the icon. However, it maybe a fragile solution as it relies on the height of the icon being the same height as the line-height.