### PR TITLE
ci: add browserstack action

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,0 +1,20 @@
+name: 'BrowserStack Test'
+
+on: workflow_dispatch
+
+jobs:
+  cypress:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSER_STACK_USERNAME }}
+          access-key: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
+      - run: npm ci
+      - run: npm run test:cypress:browserstack


### PR DESCRIPTION
## Quick description

Add a manual GitHub action to run browserstack cypress tests

## What has been achieved in this pull request?

- [x] Add GitHub Action for Cypress

## Checklist before merging
- [ ] If it is a core feature, I have added thorough tests.
- [ ] This PR stays within scope of the related issue.
