### PR TITLE
Hotfix/detail-decoration

### DIFF
--- a/packages/library/components/detail/src/detail-component.js
+++ b/packages/library/components/detail/src/detail-component.js
@@ -2,9 +2,9 @@ import { MuonElement, css, unsafeCSS } from '@muons/library';
 import { DetailMixin } from '@muons/library/mixins/detail-mixin';
 import styles from './detail-styles.css';
 import {
-  DETAIL_TOGGLE_OPEN,
-  DETAIL_TOGGLE_CLOSE,
-  DETAIL_TOGGLE_POSITION
+  DETAIL_TOGGLE_ICON_OPEN,
+  DETAIL_TOGGLE_ICON_CLOSE,
+  DETAIL_TOGGLE_ICON_POSITION
 } from '@muons/library/build/tokens/es6/muon-tokens';
 
 /**
@@ -16,9 +16,9 @@ export class Detail extends DetailMixin(MuonElement) {
 
   constructor() {
     super();
-    this._toggleOpen = DETAIL_TOGGLE_OPEN;
-    this._toggleClose = DETAIL_TOGGLE_CLOSE;
-    this._togglePosition = DETAIL_TOGGLE_POSITION;
+    this._toggleOpen = DETAIL_TOGGLE_ICON_OPEN;
+    this._toggleClose = DETAIL_TOGGLE_ICON_CLOSE;
+    this._togglePosition = DETAIL_TOGGLE_ICON_POSITION;
   }
 
   static get styles() {

--- a/packages/library/components/detail/src/detail-styles.css
+++ b/packages/library/components/detail/src/detail-styles.css
@@ -55,18 +55,23 @@
     padding-inline-end: $DETAIL_CONTENT_PADDING_INLINE;
   }
 
-  & .has-icon,
-  & .toggle-start {
-    & .content {
-      padding-inline-start: $DETAIL_CONTENT_ICON_SPACER;
-    }
+  & .decoration {
+    width: $DETAIL_DECORATION_ICON_SIZE;
+    height: $DETAIL_DECORATION_ICON_SIZE;
+    flex-shrink: 0;
   }
 
-  & .toggle,
-  & .icon {
+  & .toggle {
     width: $DETAIL_TOGGLE_ICON_SIZE;
     height: $DETAIL_TOGGLE_ICON_SIZE;
     flex-shrink: 0;
+  }
+
+  & .has-decoration,
+  & .toggle-start {
+    & .content {
+      padding-inline-start: $DETAIL_CONTENT_INLINE_SPACER;
+    }
   }
 
   & .toggle-start {

--- a/packages/library/components/detail/src/token.json
+++ b/packages/library/components/detail/src/token.json
@@ -1,21 +1,29 @@
 {
   "detail": {
     "toggle": {
-      "open": {
-        "description": "Icon to indicate the open action.",
-        "value": "chevron-circle-down"
-      },
-      "close": {
-        "description": "Icon to indicate the close action.",
-        "value": "chevron-circle-up"
-      },
-      "position": {
-        "description": "Position of the toggle icon. Valid values: `start`, `end`.",
-        "value": "end"
-      },
       "icon": {
         "size": {
           "description": "Size of the toggle icon.",
+          "value": "{ theme.size.lg.value }"
+        },
+        "open": {
+          "description": "Icon to indicate the open action.",
+          "value": "chevron-circle-down"
+        },
+        "close": {
+          "description": "Icon to indicate the close action.",
+          "value": "chevron-circle-up"
+        },
+        "position": {
+          "description": "Position of the toggle icon. Valid values: `start`, `end`.",
+          "value": "end"
+        }
+      }
+    },
+    "decoration": {
+      "icon": {
+        "size": {
+          "description": "Size of the decoration icon.",
           "value": "{ theme.size.lg.value }"
         }
       }
@@ -91,10 +99,10 @@
           "value": "{ theme.spacer.md.value }"
         }
       },
-      "icon": {
+      "inline": {
         "spacer": {
           "description": "Space at the start of the content if an icon exists at the start of the heading.",
-          "value": "calc({ detail.heading.padding.inline.value } + { detail.toggle.icon.size.value } + { detail.heading.gap.value })"
+          "value": "calc({ detail.heading.padding.inline.value } + { detail.decoration.icon.size.value } + { detail.heading.gap.value })"
         }
       }
     }

--- a/packages/library/components/detail/story.js
+++ b/packages/library/components/detail/story.js
@@ -16,9 +16,9 @@ Standard.args = {
   content: 'Yes, with an online account you can arrange a service visit, find out whatʼs happening with your appointment, submit a meter reading and book an engineer. Weʼve even got a free smartphone app.'
 };
 
-export const WithIcon = (args) => details.template(args, innerDetail);
-WithIcon.args = {
-  icon: 'dot-circle',
+export const WithDecoration = (args) => details.template(args, innerDetail);
+WithDecoration.args = {
+  decoration: 'dot-circle',
   heading: 'Can I manage my account online?',
   content: 'Yes, with an online account you can arrange a service visit, find out whatʼs happening with your appointment, submit a meter reading and book an engineer. Weʼve even got a free smartphone app.'
 };

--- a/packages/library/components/inputter/src/inputter-component.js
+++ b/packages/library/components/inputter/src/inputter-component.js
@@ -1,9 +1,9 @@
 import { html, MuonElement, ScopedElementsMixin, classMap, styleMap } from '@muons/library';
 import {
   INPUTTER_TYPE,
-  INPUTTER_DETAIL_TOGGLE_OPEN,
-  INPUTTER_DETAIL_TOGGLE_CLOSE,
-  INPUTTER_DETAIL_TOGGLE_POSITION,
+  INPUTTER_DETAIL_TOGGLE_ICON_OPEN,
+  INPUTTER_DETAIL_TOGGLE_ICON_CLOSE,
+  INPUTTER_DETAIL_TOGGLE_ICON_POSITION,
   INPUTTER_VALIDATION_WARNING_ICON,
   INPUTTER_FIELD_DATE_ICON,
   INPUTTER_FIELD_SELECT_ICON,
@@ -177,8 +177,8 @@ class InputterDetail extends DetailMixin(MuonElement) {
 
   constructor() {
     super();
-    this._toggleOpen = INPUTTER_DETAIL_TOGGLE_OPEN;
-    this._toggleClose = INPUTTER_DETAIL_TOGGLE_CLOSE;
-    this._togglePosition = INPUTTER_DETAIL_TOGGLE_POSITION;
+    this._toggleOpen = INPUTTER_DETAIL_TOGGLE_ICON_OPEN;
+    this._toggleClose = INPUTTER_DETAIL_TOGGLE_ICON_CLOSE;
+    this._togglePosition = INPUTTER_DETAIL_TOGGLE_ICON_POSITION;
   }
 }

--- a/packages/library/components/inputter/src/inputter-styles-detail.css
+++ b/packages/library/components/inputter/src/inputter-styles-detail.css
@@ -13,8 +13,8 @@
   }
 
   & .toggle {
-    width: $INPUTTER_DETAIL_ICON_SIZE;
-    height: $INPUTTER_DETAIL_ICON_SIZE;
+    width: $INPUTTER_DETAIL_TOGGLE_ICON_SIZE;
+    height: $INPUTTER_DETAIL_TOGGLE_ICON_SIZE;
     flex-shrink: 0;
   }
 

--- a/packages/library/components/inputter/src/token.json
+++ b/packages/library/components/inputter/src/token.json
@@ -273,24 +273,24 @@
           }
         }
       },
-      "icon": {
-        "size": {
-          "description": "Size of the icon used within the detail.",
-          "value": "{ theme.size.sm.value }"
-        }
-      },
       "toggle": {
-        "open": {
-          "description": "Icon used to open the detail's content.",
-          "value": "chevron-circle-down"
-        },
-        "close": {
-          "description": "Icon used to close the detail's content.",
-          "value": "chevron-circle-up"
-        },
-        "position": {
-          "description": "Position of the detail's toggle icon. Valid values: `start`, `end`.",
-          "value": "start"
+        "icon": {
+          "size": {
+            "description": "Size of the icon used within the detail.",
+            "value": "{ theme.size.sm.value }"
+          },
+          "open": {
+            "description": "Icon used to open the detail's content.",
+            "value": "chevron-circle-down"
+          },
+          "close": {
+            "description": "Icon used to close the detail's content.",
+            "value": "chevron-circle-up"
+          },
+          "position": {
+            "description": "Position of the detail's toggle icon. Valid values: `start`, `end`.",
+            "value": "start"
+          }
         }
       },
       "focus": {

--- a/packages/library/mixins/detail-mixin.js
+++ b/packages/library/mixins/detail-mixin.js
@@ -17,7 +17,7 @@ export const DetailMixin = dedupeMixin((superClass) =>
           reflect: true
         },
 
-        icon: {
+        decoration: {
           type: String
         },
 
@@ -72,7 +72,7 @@ export const DetailMixin = dedupeMixin((superClass) =>
         details: true,
         'toggle-start': this._togglePosition === 'start',
         'toggle-end': this._togglePosition === 'end',
-        'has-icon': !!this.icon
+        'has-decoration': !!this.decoration
       };
       return html`
         <details class=${classMap(classes)} ?open="${this.open}" @toggle="${this._onToggle}">
@@ -82,10 +82,10 @@ export const DetailMixin = dedupeMixin((superClass) =>
       `;
     }
 
-    get __addIcon() {
-      if (this.icon) {
+    get __addDecoration() {
+      if (this.decoration) {
         return html`
-          <detail-icon name="${this.icon}" class="icon"></detail-icon>
+          <detail-icon name="${this.decoration}" class="decoration"></detail-icon>
         `;
       }
       return undefined;
@@ -105,9 +105,9 @@ export const DetailMixin = dedupeMixin((superClass) =>
       const isToggleStart = this._togglePosition === 'start';
       return html`
         <summary class="heading">
-          ${isToggleStart ? this.__addToggle : this.__addIcon}
+          ${isToggleStart ? this.__addToggle : this.__addDecoration}
           <slot name="heading"></slot>
-          ${isToggleStart ? this.__addIcon : this.__addToggle}
+          ${isToggleStart ? this.__addDecoration : this.__addToggle}
         </summary>
       `;
     }

--- a/packages/library/tests/mixins/__snapshots__/detail.test.snap.js
+++ b/packages/library/tests/mixins/__snapshots__/detail.test.snap.js
@@ -155,10 +155,10 @@ snapshots["detail standard toggle event false"] =
 /* end snapshot detail standard toggle event false */
 
 snapshots["detail standard icon"] = 
-`<details class="details has-icon">
+`<details class="details has-decoration">
   <summary class="heading">
     <detail-icon
-      class="icon"
+      class="decoration"
       name="dot-circle"
     >
     </detail-icon>

--- a/packages/library/tests/mixins/detail.test.js
+++ b/packages/library/tests/mixins/detail.test.js
@@ -63,7 +63,7 @@ describe('detail', () => {
     const detail = shadowRoot.querySelector('details');
 
     expect(detail).to.not.be.null; // eslint-disable-line no-unused-expressions
-    const icon = detail.querySelector('.icon');
+    const icon = detail.querySelector('.decoration');
     expect(icon).to.not.be.null; // eslint-disable-line no-unused-expressions
     expect(icon.name).to.equal('dot-circle', '`icon` property has correct value');
   });


### PR DESCRIPTION
## Quick description

## What has been achieved in this pull request?

- On review of PR centrica-engineering/muon#317, it was apparent that the two icons in `details` should be treated independently. One used for toggle and the other for decoration.

In the CSS I used `DETAIL_TOGGLE_BLAH` for both icons. These should be independent of each other.

Speaking with @jholt1, I suggested we could have `DETAIL_TOGGLE_ICON_BLAH` and `DETAIL_DECORATION_ICON_BLAH` 

- [x] Change to be `TOGGLE_ICON` instead of `TOGGLE`
- [x] Use `DECORATION_ICON` instead of `ICON`
- [x] Adjusting the `inputter-details` component to fit the same token and naming structure

## Notes

Having spent a while organising this PR, I remembered the reason that I originally chose to use just the name `TOGGLE` (without `ICON`). - There's a possibility that the toggle could be a combination of words, either 'open'/'close' or 'hide/show' and not specifically an icon.

If this assumption is not the case and every instance of the details component will display an icon for the toggle, then this change can be implemented.

## Checklist before merging
- [ ] If it is a core feature, I have added thorough tests.
- [ ] This PR stays within scope of the related issue.
