### PR TITLE
feat: primary color for cta

### DIFF
--- a/packages/library/components/cta/src/token.json
+++ b/packages/library/components/cta/src/token.json
@@ -11,8 +11,8 @@
     },
     "background": {
       "color": {
-        "description": "Background color. Defaults to the darkest theme color.",
-        "value": "{ theme.color.darkest.value }"
+        "description": "Background color. Defaults to the primary theme color.",
+        "value": "{ theme.color.primary.value }"
       }
     },
     "gap": {
@@ -51,7 +51,7 @@
       "background": {
         "color": {
           "description": "Background color during the `loading` state.",
-          "value": "{ theme.color.darkest.value}"
+          "value": "{ cta.background.color.value }"
         }
       },
       "border": {
@@ -87,7 +87,7 @@
       "background": {
         "color": {
           "description": "Background color during the `hover` state.",
-          "value": "{ theme.color.darkest.value}"
+          "value": "{ theme.color.primary.value }"
         }
       },
       "border": {


### PR DESCRIPTION
## Quick description

Switch to primary color. Default tokens to the cta background color - due to keeping Muon simple and making less decisions for others.

## Checklist before merging
- [ ] If it is a core feature, I have added thorough tests.
- [ ] This PR stays within scope of the related issue.
