### PR TITLE
chore: check story location and exists

### DIFF
--- a/packages/library/storybook/find-stories.js
+++ b/packages/library/storybook/find-stories.js
@@ -13,28 +13,21 @@ const findStories = async (dir = process.cwd()) => {
   }
 
   const pathPattern = await filterPathToCustomElements(componentsList);
-
   const patterns = path.join(__filename, '..', '..', 'components', pathPattern, 'story.js');
-  if (pathIsInside(process.cwd(), path.join(__filename, '..', '..'))) {
+
+  if (
+    pathIsInside(process.cwd(), path.join(__filename, '..', '..')) ||
+    pathIsInside(path.join(__filename, '..', '..'), process.cwd())
+  ) {
     return [path.relative(dir, patterns)];
   } else {
-
-    const unlink = (fileURL) => {
-      try {
-        fs.unlinkSync(new URL(fileURL));
-        return true;
-      } catch (e) {
-        return false;
-      }
-    };
-
     const destination = config?.destination || 'dist';
     const symlink = path.join(destination, 'stories');
 
-    unlink(symlink);
-
-    fs.symlinkSync(path.join(__filename, '..', '..', 'components'),
-      symlink, 'dir');
+    if (!fs.existsSync(symlink)) {
+      fs.symlinkSync(path.join(__filename, '..', '..', 'components'),
+        symlink, 'dir');
+    }
 
     return [path.relative(dir, path.join(symlink, pathPattern, 'story.js'))];
   }


### PR DESCRIPTION
## Quick description

Fixing issue where it was symlinking when it shouldn't and that it does not break storybook when recreating the symlink

## Checklist before merging
- [ ] If it is a core feature, I have added thorough tests.
- [ ] This PR stays within scope of the related issue.
