### PR TITLE
Feature/inputter styles

### DIFF
--- a/packages/muon/components/inputter/src/inputter-styles.css
+++ b/packages/muon/components/inputter/src/inputter-styles.css
@@ -233,7 +233,7 @@
       width: fit-content;
 
       & inputter-icon {
-        right: calc($INPUTTER_FIELD_PADDING_INLINE_END + $INPUTTER_FIELD_BORDER_WIDTH);
+        right: calc($INPUTTER_FIELD_BORDER_WIDTH + ($INPUTTER_FIELD_PADDING_INLINE_END / 2));
       }
     }
   }
@@ -241,7 +241,7 @@
   & .search {
     & .wrapper {
       & inputter-icon {
-        left: calc($INPUTTER_FIELD_PADDING_INLINE_START + $INPUTTER_FIELD_BORDER_WIDTH);
+        left: calc($INPUTTER_FIELD_BORDER_WIDTH + ($INPUTTER_FIELD_PADDING_INLINE_START / 2));
       }
     }
   }


### PR DESCRIPTION
## Quick description

## What has been achieved in this pull request?

- [x] `fit-content` is only required on `date` and `select` fields, and not on the `search` field.
- [x] Adjust calculated position of inputter-icon so that the icon sits centrally in the padding rather than tight to the edge.

## Related issues

#

## Checklist before merging
- [ ] If it is a core feature, I have added thorough tests.
- [ ] This PR stays within scope of the related issue.
