### PR TITLE
Feature/inputter styles

### DIFF
--- a/packages/muon/components/inputter/src/design-tokens.json
+++ b/packages/muon/components/inputter/src/design-tokens.json
@@ -103,7 +103,7 @@
       "row": {
         "gap": {
           "description": "Gap between radio button, checkbox and their label.",
-          "value": "0.5em"
+          "value": "{ theme.spacer.sm.value }"
         }
       },
       "size": {
@@ -114,6 +114,30 @@
         "color": {
           "description": "Border color for the radio button and checkbox.",
           "value": "{ inputter.field.color.value }"
+        }
+      },
+      "label": {
+        "padding": {
+          "inline": {
+            "start": {
+              "description": "The padding inline start of the label for the radio button and checkbox.",
+            "value": "{ theme.spacer.sm.value }"
+            },
+            "end": {
+              "description": "The padding inline end of the label for the radio button and checkbox.",
+            "value": "{ theme.spacer.sm.value }"
+            }
+          },
+          "block": {
+            "start": {
+              "description": "The padding block start of the label for the radio button and checkbox.",
+              "value": "initial"
+            },
+            "end": {
+              "description": "The padding block end of the label for the radio button and checkbox.",
+              "value": "initial"
+            }
+          }
         }
       }
     },

--- a/packages/muon/components/inputter/src/design-tokens.json
+++ b/packages/muon/components/inputter/src/design-tokens.json
@@ -121,11 +121,11 @@
           "inline": {
             "start": {
               "description": "The padding inline start of the label for the radio button and checkbox.",
-            "value": "{ theme.spacer.sm.value }"
+              "value": "{ theme.spacer.sm.value }"
             },
             "end": {
               "description": "The padding inline end of the label for the radio button and checkbox.",
-            "value": "{ theme.spacer.sm.value }"
+              "value": "{ theme.spacer.sm.value }"
             }
           },
           "block": {
@@ -149,6 +149,32 @@
           "size": {
             "description": "Size of the radio button dot. Use an `em` unit to scale with label.",
             "value": "0.25em"
+          }
+        }
+      },
+      "checkbox": {
+        "check": {
+          "width": {
+            "description": "The length of the short side of the checkbox check.",
+            "value": "0.25em"
+          },
+          "height": {
+            "description": "The length of the long side of the checkbox check.",
+            "value": "0.5em"
+          },
+          "size": {
+            "description": "The width of the checkbox check.",
+            "value": "0.125em"
+          },
+          "color": {
+            "description": "The colour of the checkbox check.",
+            "value": "{ inputter.field.color.value }"
+          }
+        },
+        "border": {
+          "radius": {
+            "description": "Border radius of the checkbox. 0.1875em is equal to 3px when font-size is 16px.",
+            "value": "1em"
           }
         }
       }

--- a/packages/muon/components/inputter/src/design-tokens.json
+++ b/packages/muon/components/inputter/src/design-tokens.json
@@ -139,6 +139,18 @@
             }
           }
         }
+      },
+      "radio": {
+        "dot": {
+          "color": {
+            "description": "Color of the radio dot.",
+            "value": "{ inputter.field.color.value }"
+          },
+          "size": {
+            "description": "Size of the radio button dot. Use an `em` unit to scale with label.",
+            "value": "0.25em"
+          }
+        }
       }
     },
     "label": {

--- a/packages/muon/components/inputter/src/design-tokens.json
+++ b/packages/muon/components/inputter/src/design-tokens.json
@@ -100,9 +100,11 @@
           "value": "{ inputter.field.background.color.value }"
         }
       },
-      "gap": {
-        "description": "Gap between radio button, checkbox and their label.",
-        "value": "0.5em"
+      "row": {
+        "gap": {
+          "description": "Gap between radio button, checkbox and their label.",
+          "value": "0.5em"
+        }
       },
       "size": {
         "description": "Size of the radio button and checkbox. Use an `em` unit to scale with label.",

--- a/packages/muon/components/inputter/src/design-tokens.json
+++ b/packages/muon/components/inputter/src/design-tokens.json
@@ -131,6 +131,9 @@
             "value": "{ theme.spacer.sm.value }"
           }
         }
+      },
+      "lineLength": {
+        "value": "{ theme.font.lineLength.value }"
       }
     },
     "placeholder": {

--- a/packages/muon/components/inputter/src/design-tokens.json
+++ b/packages/muon/components/inputter/src/design-tokens.json
@@ -174,7 +174,7 @@
         "border": {
           "radius": {
             "description": "Border radius of the checkbox. 0.1875em is equal to 3px when font-size is 16px.",
-            "value": "1em"
+            "value": "0.1875em"
           }
         }
       }

--- a/packages/muon/components/inputter/src/design-tokens.json
+++ b/packages/muon/components/inputter/src/design-tokens.json
@@ -177,6 +177,20 @@
             "value": "0.1875em"
           }
         }
+      },
+      "hover": {
+        "background": {
+          "color": {
+            "description": "Background color of the radio button and checkbox on `hover` state.",
+            "value": "{ inputter.hover.color.value }"
+          }
+        },
+        "border": {
+          "color": {
+            "description": "Border color of the radio button and checkbox on `hover` state.",
+            "value": "{ inputter.hover.color.value }"
+          }
+        }
       }
     },
     "label": {

--- a/packages/muon/components/inputter/src/inputter-styles.css
+++ b/packages/muon/components/inputter/src/inputter-styles.css
@@ -152,7 +152,7 @@
     }
 
     & ::slotted(input[type="checkbox"]) {
-      border-radius: 0.1875em; /* NOTE: equal to 3px when font-size is 16px */
+      border-radius: $INPUTTER_MULTIPLE_CHECKBOX_BORDER_RADIUS;
     }
 
     & ::slotted(input[type="radio"]) {
@@ -160,7 +160,6 @@
     }
 
     & ::slotted(input[type="radio"]:checked)::before {
-      display: block;
       content: "";
       width: 0;
       height: 0;
@@ -171,13 +170,12 @@
     }
 
     & ::slotted(input[type="checkbox"]:checked)::before {
-      display: block;
       content: "";
-      width: 0.25em;
-      height: 0.5em;
-      border-width: 0.125em;
+      width: $INPUTTER_MULTIPLE_CHECKBOX_CHECK_WIDTH;
+      height: $INPUTTER_MULTIPLE_CHECKBOX_CHECK_HEIGHT;
+      border-width: $INPUTTER_MULTIPLE_CHECKBOX_CHECK_SIZE;
       border-style: solid;
-      border-color: $INPUTTER_MULTIPLE_BORDER_COLOR;
+      border-color: $INPUTTER_MULTIPLE_CHECKBOX_CHECK_COLOR;
       border-top: unset;
       border-right-style: solid;
       border-bottom-style: solid;

--- a/packages/muon/components/inputter/src/inputter-styles.css
+++ b/packages/muon/components/inputter/src/inputter-styles.css
@@ -8,6 +8,7 @@
     margin-block-start: $INPUTTER_LABEL_MARGIN_BLOCK_START;
     margin-block-end: $INPUTTER_LABEL_MARGIN_BLOCK_END;
     color: $INPUTTER_LABEL_COLOR;
+    max-width: $INPUTTER_LABEL_LINE_LENGTH;
   }
 
   & ::slotted(*)::placeholder {

--- a/packages/muon/components/inputter/src/inputter-styles.css
+++ b/packages/muon/components/inputter/src/inputter-styles.css
@@ -188,6 +188,12 @@
     & ::slotted(label) {
       display: block;
       width: fit-content;
+      margin-block-start: revert; /* NOTE: @drew - 2023-05-18 - revert these to use padding instead, could benefit from using a `:not(.multiple)` on line 6 */
+      margin-block-end: revert; /* NOTE: @drew - 2023-05-18 - revert these to use padding instead, could benefit from using a `:not(.multiple)` on line 6 */
+      padding-inline-start: $INPUTTER_MULTIPLE_LABEL_PADDING_INLINE_START;
+      padding-inline-end: $INPUTTER_MULTIPLE_LABEL_PADDING_INLINE_END;
+      padding-block-start: $INPUTTER_MULTIPLE_LABEL_PADDING_BLOCK_START;
+      padding-block-end: $INPUTTER_MULTIPLE_LABEL_PADDING_BLOCK_END;
     }
 
     & ::slotted(label:hover) {

--- a/packages/muon/components/inputter/src/inputter-styles.css
+++ b/packages/muon/components/inputter/src/inputter-styles.css
@@ -106,8 +106,7 @@
       display: grid; /* NOTE: using `grid` to control the layout of `<input>` and `<label>` */
       line-height: 1.2; /* NOTE: setting `line-height` here to control the position of the checkbox and radio input */
       grid-template-columns: $INPUTTER_MULTIPLE_SIZE auto;
-      column-gap: $INPUTTER_MULTIPLE_GAP;
-      row-gap: $INPUTTER_MULTIPLE_GAP;
+      row-gap: $INPUTTER_MULTIPLE_ROW_GAP;
     }
 
     & ::slotted(:is(

--- a/packages/muon/components/inputter/src/inputter-styles.css
+++ b/packages/muon/components/inputter/src/inputter-styles.css
@@ -128,7 +128,8 @@
     & ::slotted(:is(
     input[type="checkbox"]:hover,
     input[type="radio"]:hover)) {
-      border-color: $INPUTTER_HOVER_BORDER_COLOR;
+      background-color: $INPUTTER_MULTIPLE_HOVER_BACKGROUND_COLOR;
+      border-color: $INPUTTER_MULTIPLE_HOVER_BORDER_COLOR;
     }
 
     & ::slotted(:is(

--- a/packages/muon/components/inputter/src/inputter-styles.css
+++ b/packages/muon/components/inputter/src/inputter-styles.css
@@ -164,9 +164,9 @@
       content: "";
       width: 0;
       height: 0;
-      border-width: 0.25em;
+      border-width: $INPUTTER_MULTIPLE_RADIO_DOT_SIZE;
       border-style: solid;
-      border-color: $INPUTTER_MULTIPLE_BORDER_COLOR;
+      border-color: $INPUTTER_MULTIPLE_RADIO_DOT_COLOR;
       border-radius: 50%;
     }
 

--- a/packages/muon/tokens/theme/font.json
+++ b/packages/muon/tokens/theme/font.json
@@ -55,6 +55,10 @@
           "description": "Weight of the font used for headings.",
           "value": "600"
         }
+      },
+      "lineLength": {
+        "description": "Suggested longest line length of any typography.",
+        "value": "60ch"
       }
     }
   }


### PR DESCRIPTION
## Quick description

## What has been achieved in this pull request?

- [x] Include global lineLength token and use it for the label.
- [x] Use only a row-gap for the space between radio/checkboxes and replace the column-gap with padding for label spacing. This keeps the interactive 'touch' area more predictable.
- [x] Tokens for the size and colour of the radio 'dot' and checkbox 'check'.

## Related issues

#

## Checklist before merging
- [ ] If it is a core feature, I have added thorough tests.
- [ ] This PR stays within scope of the related issue.
