### PR TITLE
feat(rollup): replace `$(prefix)` with config prefix

### DIFF
--- a/packages/muon/scripts/rollup-plugins.mjs
+++ b/packages/muon/scripts/rollup-plugins.mjs
@@ -144,10 +144,20 @@ const replaceConfig = {
   }
 };
 
+const replacePrefixConfig = {
+  preventAssignment: false,
+  delimiters: ['', ''],
+  include: ['**/*.css'],
+  values: {
+    '$(prefix)': config?.components?.prefix
+  }
+};
+
 export const serverPlugins = [
   buildTokens(),
   alias(aliasConfig),
   replace(replaceConfig),
+  replace(replacePrefixConfig),
   styles(styleConfig),
   litcss({ exclude: ['**/css/*.css', '**/dist/*.css', 'muon.min.css', '**/**/*.slotted.css'] }),
   css({ include: '**/**/*.slotted.css' }),
@@ -158,6 +168,7 @@ export const rollupPlugins = [
   buildTokensPlugin(),
   aliasPlugin(aliasConfig),
   replacePlugin(replaceConfig),
+  replace(replacePrefixConfig),
   stylesPlugin(styleConfig),
   litcssPlugin({
     exclude: ['**/css/*.css', '**/dist/*.css', 'muon.min.css', '**/**/*.slotted.css'],


### PR DESCRIPTION
# Discovery: injecting prefix into css component selectors

Added config and a new rollup replace instance before the css starts processing. 
This prevents issues with string interpolation and nesting, and allows replacement of the prefix (using postCss plugins to do this work resulted in errors either to do with string interpolation issues or nesting issues, depending on the fix applied).

## Quick description

## What has been achieved in this pull request?

In the design system, allows the use of a prefix variable in the css files. 

_muon config_
```json
{
  "components": {
    "prefix": "ns"
  }
}
```

```css
  &[type="standard"] {
    &[pill-over-image] {
      position: relative;

      & $(prefix)-pill {
      ...
      }
    }
  }

/*  outputs to, in Nucleus */
  &[type="standard"] {
    &[pill-over-image] {
      position: relative;

      & ns-pill {
      ...
      }
    }
  }
```



## Related issues

#

## Checklist before merging
- [ ] If it is a core feature, I have added thorough tests.
- [x] This PR stays within scope of the related issue.
