### PR TITLE
fix: register form events after a timeout

### DIFF
--- a/packages/muon/components/form/src/form-component.js
+++ b/packages/muon/components/form/src/form-component.js
@@ -26,7 +26,6 @@ export class Form extends MuonElement {
     queueMicrotask(() => {
       this.__checkForFormEl();
       if (this._nativeForm) {
-        this.__registerEvents();
         // hack to stop browser validation pop up
         this._nativeForm.setAttribute('novalidate', true);
         // hack to force implicit submission (https://github.com/WICG/webcomponents/issues/187)
@@ -38,6 +37,12 @@ export class Form extends MuonElement {
         }
       }
     });
+
+    setTimeout(() => {
+      if (this._nativeForm) {
+        this.__registerEvents();
+      }
+    }, 0);
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
Delay the registration of events until after the next microtask.

## Quick description

## What has been achieved in this pull request?

- [x] Achievement completed

## Related issues

#

## Checklist before merging
- [ ] If it is a core feature, I have added thorough tests.
- [ ] This PR stays within scope of the related issue.
