### PR TITLE
fix: register events after update cycle

### DIFF
--- a/packages/muon/components/form/src/form-component.js
+++ b/packages/muon/components/form/src/form-component.js
@@ -26,7 +26,9 @@ export class Form extends MuonElement {
     queueMicrotask(() => {
       this.__checkForFormEl();
       if (this._nativeForm) {
-        this.__registerEvents();
+        this.updateComplete.then(() => {
+          this.__registerEvents();
+        });
         // hack to stop browser validation pop up
         this._nativeForm.setAttribute('novalidate', true);
         // hack to force implicit submission (https://github.com/WICG/webcomponents/issues/187)
@@ -45,25 +47,18 @@ export class Form extends MuonElement {
     this.__teardownEvents();
   }
 
+  firstUpdated() {
+    super.firstUpdated();
+
+    this._submitButton?.updateComplete?.then(() => {});
+    this._resetButton?.updateComplete?.then(() => {});
+  }
+
   __registerEvents() {
     this._nativeForm?.addEventListener('submit', this._submit);
-    const submitButton = this._submitButton;
-    if (submitButton?.updateComplete) {
-      submitButton.updateComplete.then(() => {
-        submitButton.addEventListener('click', this._submit);
-      });
-    } else {
-      submitButton?.addEventListener('click', this._submit);
-    }
+    this._submitButton?.addEventListener('click', this._submit);
     this._nativeForm?.addEventListener('reset', this._reset);
-    const resetButton = this._resetButton;
-    if (resetButton?.updateComplete) {
-      resetButton.updateComplete.then(() => {
-        resetButton.addEventListener('click', this._reset);
-      });
-    } else {
-      resetButton?.addEventListener('click', this._reset);
-    }
+    this._resetButton?.addEventListener('click', this._reset);
   }
 
   __teardownEvents() {


### PR DESCRIPTION
## Quick description

## What has been achieved in this pull request?

- [x] Register the event after the update cycle completes

## Related issues

#

## Checklist before merging
- [ ] If it is a core feature, I have added thorough tests.
- [ ] This PR stays within scope of the related issue.
