### PR TITLE
Discovery/nested styling/regex replace

### DIFF
--- a/packages/muon/muon-element/index.js
+++ b/packages/muon/muon-element/index.js
@@ -4,6 +4,9 @@ import { html, LitElement, adoptStyles, supportsAdoptingStyleSheets } from '@muo
  * @typedef {module:lit.CSSResultOrNative} CSSResultOrNative - define css type
  */
 
+const prefixRegex = /prefix/g;
+const prefix = process.env.MUON_PREFIX;
+
 export const MuonElementMixin = (superClass) => class extends superClass {
 
   static get properties() {
@@ -25,6 +28,21 @@ export const MuonElementMixin = (superClass) => class extends superClass {
   }
 
   /**
+   * Helper to replace 'prefix' with 'process.env.MUON_PREFIX' in CSS text.
+   * @param {string} cssText
+   * @returns {string}
+   *
+   * @example
+   * static get styles() {
+   *   return css([this.processPrefix(styles.cssText)]);
+   * }
+   */
+
+  static processPrefix(cssText) {
+    return typeof cssText === 'string' ? cssText.replace(prefixRegex, prefix) : cssText;
+  }
+
+  /**
    * A method to inject light DOM styles into parent.
    * This currently has some limitations:
    * - Cannot easily target the element with attributes.
@@ -43,8 +61,8 @@ export const MuonElementMixin = (superClass) => class extends superClass {
     const processCss = (css, nodeName) => {
       return css
         .replace(/light-dom/g, nodeName)
-        .replace(/prefix/g, 'ns');
-    }
+        .replace(prefixRegex, prefix);
+    };
 
     this.updateComplete.then(() => {
       const css = this.slottedStyles;

--- a/packages/muon/tests/mixins/muon-element.test.js
+++ b/packages/muon/tests/mixins/muon-element.test.js
@@ -38,6 +38,10 @@ const MultipleScopedStyles = class extends MuonElement {
 };
 
 const prefixScopedComponentStyles = class extends MuonElement {
+  get styles() {
+    return css([this.processPrefix(':host { prefix-test { margin-inline-end: 20px;}')]);
+  }
+
   get slottedStyles() {
     return [
       'prefix-test-component { color: red; }',
@@ -108,15 +112,15 @@ describe('muon-component', () => {
   it('prefix is replaced for styles', async () => {
     const element = await fixture(html`
       <${prefixScopedComponentStylesTag}>
-        <ns-test-component>test</ns-test-component>
-        <nsx-test-component>test</nsx-test-component>
+        <muon-test-component>test</muon-test-component>
+        <muonx-test-component>test</muonx-test-component>
       </${prefixScopedComponentStylesTag}>
     `);
-    const nsComponent = element.querySelector('ns-test-component');
-    const nsxComponent = element.querySelector('nsx-test-component');
+    const nsComponent = element.querySelector('muon-test-component');
+    const nsxComponent = element.querySelector('muonx-test-component');
 
-    expect(getComputedStyle(nsComponent).color).to.equal('rgb(255, 0, 0)', 'prefix was replaced with ns in styles');
-    expect(getComputedStyle(nsxComponent).color).to.equal('rgb(0, 0, 255)', 'prefix was replaced with ns in styles');
+    expect(getComputedStyle(nsComponent).color).to.equal('rgb(255, 0, 0)', 'prefix was replaced with config prefix & styles successfully applied');
+    expect(getComputedStyle(nsxComponent).color).to.equal('rgb(0, 0, 255)', 'prefixx was replaced with config prefixx & styles successfully applied');
   });
 
   it('broken scoped styles', async () => {


### PR DESCRIPTION
![Static Badge](https://img.shields.io/badge/discovery-blue)

# Using regex to replace `prefix` in css

This PR adds a small piece of functionality that, exactly like the current functionality of the replacement of any instance of `light-dom`, replaces all instances of `prefix` with the variable `MUON_PREFIX` in css files.

> [!WARNING]
> ## Only works in the light-dom styles
> Adding this code where I have does not effect all css. When i tested this in Nucleus, the nsx-filter component's css did not update. The workaround I have ended up with is a helper that comes with `MuonElement`. Not ideal for many reasons (the main big one being that we'd have to update any component that needs it, and it's not currently easy to test for within components) but it works, at least. 
> 
```js
/**
   * Helper to replace 'prefix' with 'process.env.MUON_PREFIX' in CSS text.
   * @param {string} cssText
   * @returns {string}
   *
   * @example
   * static get styles() {
   *   return css([this.processPrefix(styles.cssText)]);
   * }
   */

  static processPrefix(cssText) {
    return typeof cssText === 'string' ? cssText.replace(prefixRegex, prefix) : cssText;
  }
```

## Currently uses plain `prefix` word rather than variable
I have tried with some other syntaxes (such as `${prefix})` but so far, postCss has not been happy. The good thing at least, about the word `prefix` itself, is that it's not used in css anywhere so will never become an issue. From a DevEx perspective it's not great as it's not visually indicated as a variable:

```css
/*  prefix on its own is not as easy to spot as a variable - compare the two examples below to see what I mean  */

prefix-pill { styles }
${prefix}-pill { styles }
```

## What has been achieved in this pull request?

In terms of the discovery, it can be concluded that utilising the same functionality to regex-replace all prefixes requires extra work to make it a reality for all components, which makes it non-viable for continuation. The implication of this solution is to go through every component and find css that's not light-dom scoped, to apply the `prefix` variable and logic. It's too dangerous. 

- [x] Added a new function which encapsulates the regex replacement of any instances of `prefix` as well as the `light dom`
- [x] Added tests to cover instances of `*s` and `*sx` prefixed components

## What didn't get completed?
- [ ] The tests do not currently cover the functionality of the helper

## Related issues

#

## Checklist before merging
- [ ] If it is a core feature, I have added thorough tests.
- [ ] This PR stays within scope of the related issue.
